### PR TITLE
Fix async mode and adapt threads for testing

### DIFF
--- a/api.py
+++ b/api.py
@@ -37,7 +37,8 @@ from token_tracker import token_tracker
 app = Flask(__name__)
 app.config["SECRET_KEY"] = os.environ.get("FLASK_SECRET_KEY", os.urandom(24))
 CORS(app)
-socketio = SocketIO(app, cors_allowed_origins="*", async_mode="asyncio")
+# Use the eventlet async mode to match the Gunicorn worker class
+socketio = SocketIO(app, cors_allowed_origins="*", async_mode="eventlet")
 
 login_manager = LoginManager()
 login_manager.init_app(app)


### PR DESCRIPTION
## Summary
- use `eventlet` async mode for SocketIO
- guard against DummyThread in integrated system
- provide dummy executor when threads are patched
- avoid accessing missing agent attributes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863f8287540832496287cdf5b226133