### PR TITLE
Fix fallback when frontend build missing

### DIFF
--- a/api.py
+++ b/api.py
@@ -825,12 +825,22 @@ def search_logs():
 # Serve frontend static files
 @app.route("/")
 def serve_frontend():
-    return send_from_directory("frontend/dist", "index.html")
+    """Serve the built frontend if available, otherwise fall back to the source files."""
+    dist_dir = os.path.join("frontend", "dist")
+    if os.path.exists(os.path.join(dist_dir, "index.html")):
+        return send_from_directory(dist_dir, "index.html")
+    # If the frontend hasn't been built, serve the unbundled source version
+    return send_from_directory("frontend", "index.html")
 
 
 @app.route("/<path:path>")
 def serve_static(path):
-    return send_from_directory("frontend/dist", path)
+    """Serve static assets from the built frontend or the source directory."""
+    dist_dir = os.path.join("frontend", "dist")
+    dist_path = os.path.join(dist_dir, path)
+    if os.path.exists(dist_path):
+        return send_from_directory(dist_dir, path)
+    return send_from_directory("frontend", path)
 
 
 # WebSocket events


### PR DESCRIPTION
## Summary
- serve `frontend/index.html` when `frontend/dist` is absent
- add same fallback for static assets

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686400da6998832487db767ed967eef9