### PR TITLE
Improve frontend fallback and debug feedback

### DIFF
--- a/api.py
+++ b/api.py
@@ -825,12 +825,32 @@ def search_logs():
 # Serve frontend static files
 @app.route("/")
 def serve_frontend():
-    return send_from_directory("frontend/dist", "index.html")
+    """Serve the built frontend if available, otherwise fall back to the source files."""
+    dist_dir = os.path.join("frontend", "dist")
+    dist_index = os.path.join(dist_dir, "index.html")
+    if os.path.exists(dist_index):
+        return send_from_directory(dist_dir, "index.html")
+    # If the frontend hasn't been built, serve the unbundled source version
+    fallback_index = os.path.join("frontend", "index.html")
+    if os.path.exists(fallback_index):
+        return send_from_directory("frontend", "index.html")
+    # In development environments a missing index file would cause a 404.
+    # Display a simple message to aid debugging instead of failing silently.
+    return (
+        "<h1>Frontend not found.\n" "Ensure the React app is built.</h1>",
+        200,
+        {"Content-Type": "text/html"},
+    )
 
 
 @app.route("/<path:path>")
 def serve_static(path):
-    return send_from_directory("frontend/dist", path)
+    """Serve static assets from the built frontend or the source directory."""
+    dist_dir = os.path.join("frontend", "dist")
+    dist_path = os.path.join(dist_dir, path)
+    if os.path.exists(dist_path):
+        return send_from_directory(dist_dir, path)
+    return send_from_directory("frontend", path)
 
 
 # WebSocket events

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -9,5 +9,20 @@
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
+    <script>
+      // Display a debug message if the React app fails to mount
+      window.addEventListener('DOMContentLoaded', function () {
+        setTimeout(function () {
+          const root = document.getElementById('root');
+          if (!root || !root.hasChildNodes()) {
+            const debug = document.createElement('div');
+            debug.textContent = 'DEBUG: Frontend assets failed to load.';
+            debug.style.background = '#fee';
+            debug.style.padding = '1em';
+            document.body.appendChild(debug);
+          }
+        }, 2000);
+      });
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- show friendly message if both built and source `index.html` are missing
- display a debug message in the source `index.html` when React fails to mount

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686400da6998832487db767ed967eef9