### PR TITLE
Fix Render login DB issue

### DIFF
--- a/api.py
+++ b/api.py
@@ -156,6 +156,14 @@ def load_user(user_id):
         return User(row["id"], row["username"], row["password_hash"])
     return None
 
+# Initialize the user database when the module is imported. This ensures
+# the required table and default admin account exist even if the script is
+# run via Gunicorn without executing the ``__main__`` section.
+try:
+    init_user_db()
+except Exception as init_err:
+    print(f"[DB] Failed to initialize user database: {init_err}")
+
 
 # Global state
 simulation_state = {


### PR DESCRIPTION
## Summary
- ensure user DB is created when `api.py` is imported

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68652041f1948324816559c7875a6f25