### PR TITLE
Fix MIPROv2 optimizer error

### DIFF
--- a/wizard_improver.py
+++ b/wizard_improver.py
@@ -629,6 +629,7 @@ JUDGE EVALUATION:
                 metric=metric,
                 num_candidates=mipro_settings.get("num_candidates", 8),
                 init_temperature=mipro_settings.get("init_temperature", 1.0),
+                auto=None,
                 verbose=True,
                 track_stats=mipro_settings.get("track_stats", True)
             )


### PR DESCRIPTION
## Summary
- ensure MIPROv2 runs with custom parameters by disabling `auto`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68652637635c83248ee78d68fa27bcd3