### PR TITLE
Use gpt-4.1-nano model

### DIFF
--- a/test_miprov2.py
+++ b/test_miprov2.py
@@ -66,7 +66,7 @@ def running_interactively() -> bool:
             try:
                 dspy.settings.configure(
                     lm=dspy.LM(
-                        model="gpt-3.5-turbo",
+                        model="gpt-4.1-nano",
                         temperature=0.3,
                         max_tokens=512,
                     )
@@ -184,7 +184,7 @@ def running_interactively() -> bool:
             if "model" in error_str:
                 print("⚠ Possible model issue")
                 print(f"  - Current model: {config.LLM_MODEL}")
-                print("  - Try using 'gpt-3.5-turbo' instead")
+                print("  - Try using 'gpt-4.1-nano' instead")
             
             if "minibatch" in error_str or "batch" in error_str:
                 print("⚠ Possible batch size issue")

--- a/wizard_improver.py
+++ b/wizard_improver.py
@@ -598,7 +598,7 @@ JUDGE EVALUATION:
             except Exception as e:
                 print(f"[TRAINING] Error configuring DSPy with model {model_name}: {e}")
                 # Try fallback model
-                fallback_model = "gpt-3.5-turbo"
+                fallback_model = "gpt-4.1-nano"
                 print(f"[TRAINING] Trying fallback model: {fallback_model}")
                 dspy.settings.configure(
                     lm=dspy.LM(


### PR DESCRIPTION
## Summary
- switch fallback model references from `gpt-3.5-turbo` to `gpt-4.1-nano`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68669e9a87ac8324855f4aeb920f04a4