### PR TITLE
Add script entry point for test_miprov2

### DIFF
--- a/test_miprov2.py
+++ b/test_miprov2.py
@@ -235,3 +235,6 @@ def main() -> None:
         print("TEST COMPLETE")
         print("=" * 60)
 
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- enable running `test_miprov2.py` directly by adding a `__main__` block

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866a7bdea0883248817266471ad4f26