### PR TITLE
Fix missing formatting arg in synthetic generation

### DIFF
--- a/wizard_improver.py
+++ b/wizard_improver.py
@@ -179,7 +179,8 @@ if dspy is not None:
                             situation_type=situation,
                             research_topic=topic,
                             validation_statement=validation,
-                            follow_up_question=follow_up
+                            follow_up_question=follow_up,
+                            emotional_impact=impact
                         )
                     else:
                         participant_text = exchange.get("participant", random.choice(response_patterns["brief_responses"]))


### PR DESCRIPTION
## Summary
- add `emotional_impact` placeholder when formatting synthetic wizard lines

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866ab7bea048324b0272214c5db37e4